### PR TITLE
Add experiment replication scripts and epoch-based checkpointing

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,198 @@
+# Learning Dynamics of LLM Finetuning - Experiment Scripts
+
+This directory contains scripts for replicating the experiments from the paper "Learning Dynamics of LLM Finetuning".
+
+## Quick Start
+
+```bash
+# 1. Set up the environment
+bash scripts/setup_environment.sh
+
+# 2. Activate the environment
+conda activate learntune
+
+# 3. Run all experiments
+bash scripts/run_all_experiments.sh
+```
+
+## System Requirements
+
+- **GPU**: NVIDIA RTX PRO 6000 (97GB VRAM) or equivalent
+- **CUDA**: 12.x or 13.x
+- **RAM**: 32GB minimum
+- **Storage**: 50GB for models and checkpoints
+
+## Scripts Overview
+
+### Environment Setup
+- `setup_environment.sh` - Creates conda environment with all dependencies
+
+### Training Scripts
+- `train_sft_base.sh` - SFT training with train_dpo split (2 epochs, 10000 examples)
+- `train_sft_extend.sh` - SFT training with train_sft_extend split (2 epochs, 10000 examples)
+- `train_dpo_base.sh` - DPO training on SFT base (6 epochs, saves at 2,4,6)
+- `train_dpo_extend.sh` - DPO training on SFT extend (6 epochs, saves at 2,4,6)
+
+### Inference & Evaluation
+- `generate_inference_samples.sh` - Generate model responses for evaluation
+- `evaluate_models.py` - Compare two models using GPT/Claude as judge
+
+### Master Script
+- `run_all_experiments.sh` - Runs the complete experiment pipeline
+
+## Detailed Instructions
+
+### Step 1: Environment Setup
+
+```bash
+cd /home/llm/arp/learntune/Learning_dynamics_LLM
+bash scripts/setup_environment.sh
+conda activate learntune
+```
+
+### Step 2: Verify GPU Setup
+
+```bash
+python -c "import torch; print(f'GPUs: {torch.cuda.device_count()}')"
+```
+
+### Step 3: Run SFT Training
+
+```bash
+# Run base SFT (uses train_dpo split)
+bash scripts/train_sft_base.sh
+
+# Run extend SFT (uses train_sft_extend split)
+bash scripts/train_sft_extend.sh
+```
+
+### Step 4: Run DPO Training
+
+```bash
+# Run DPO on base SFT (saves checkpoints at epochs 2, 4, 6)
+bash scripts/train_dpo_base.sh
+
+# Run DPO on extend SFT (saves checkpoints at epochs 2, 4, 6)
+bash scripts/train_dpo_extend.sh
+```
+
+### Step 5: Generate Inference Samples
+
+```bash
+# Generate samples from a specific checkpoint
+bash scripts/generate_inference_samples.sh qwen18 qwen18_dpo_base_ep6
+
+# Generate samples from a specific epoch
+bash scripts/generate_inference_samples.sh qwen18 qwen18_dpo_base_ep6 epoch_4
+```
+
+### Step 6: Run Evaluation
+
+```bash
+# Set your API key (choose one)
+export ANTHROPIC_API_KEY="your-key-here"
+# OR
+export OPENAI_API_KEY="your-key-here"
+
+# Run evaluation
+cd scripts
+python evaluate_models.py \
+    --model_a gen_qwen18_dpo_base_ep6 \
+    --model_b gen_qwen18_dpo_extend_ep6 \
+    --evaluator claude
+```
+
+## Experiment Configuration
+
+### SFT Training
+| Parameter | Value |
+|-----------|-------|
+| Model | Qwen 1.8B |
+| Epochs | 2 |
+| Examples | 10,000 |
+| Batch Size | 4 |
+| Learning Rate | 5e-7 |
+
+### DPO Training
+| Parameter | Value |
+|-----------|-------|
+| Model | Qwen 1.8B |
+| Epochs | 6 |
+| Examples | 30,000 |
+| Batch Size | 2 |
+| Learning Rate | 5e-7 |
+| Beta | 0.1 |
+| Save Epochs | 2, 4, 6 |
+
+## Output Structure
+
+After running all experiments, you'll have:
+
+```
+exp_results/
+├── qwen18_sft_base_ep2/
+│   ├── policy.pt
+│   ├── optimizer.pt
+│   ├── scheduler.pt
+│   └── prob_train_metrics.json
+├── qwen18_sft_extend_ep2/
+│   └── ...
+├── qwen18_dpo_base_ep6/
+│   ├── epoch_2/
+│   │   └── policy.pt
+│   ├── epoch_4/
+│   │   └── policy.pt
+│   ├── epoch_6/
+│   │   └── policy.pt
+│   └── policy.pt (final)
+├── qwen18_dpo_extend_ep6/
+│   └── ...
+├── gen_qwen18_dpo_base_ep6/
+│   ├── prob_test_gen_response.jsonl
+│   └── ...
+└── gen_qwen18_dpo_extend_ep6/
+    └── ...
+```
+
+## GPU Usage
+
+The scripts are configured to use specific GPUs:
+- GPU 0: SFT Base, DPO Base
+- GPU 1: SFT Extend, DPO Extend
+
+To run training in parallel on different GPUs:
+
+```bash
+# Terminal 1
+bash scripts/train_sft_base.sh &
+
+# Terminal 2
+bash scripts/train_sft_extend.sh &
+```
+
+## Troubleshooting
+
+### CUDA Out of Memory
+- Reduce batch size in the training scripts
+- For DPO, batch_size=2 is recommended
+
+### Missing Checkpoint Error
+- Ensure SFT training completed before running DPO
+- Check `exp_results/<exp_name>/policy.pt` exists
+
+### API Rate Limiting (Evaluation)
+- The evaluation script includes 0.5s delay between requests
+- Increase delay if you hit rate limits
+
+## Weights & Biases
+
+Training logs are automatically sent to W&B. To disable:
+```bash
+# Add to training command
+wandb.enabled=false
+```
+
+To change project name:
+```bash
+wandb.project="your_project_name"
+```

--- a/scripts/evaluate_models.py
+++ b/scripts/evaluate_models.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python
+"""
+============================================================================
+Model Evaluation Script
+============================================================================
+This script evaluates model responses using GPT or Claude as the judge.
+It compares responses from two different models/checkpoints and computes
+win rates.
+
+Usage:
+    python evaluate_models.py --model_a <exp_name_a> --model_b <exp_name_b>
+
+Example:
+    python evaluate_models.py --model_a qwen18_dpo_base_ep6 --model_b qwen18_dpo_extend_ep6
+============================================================================
+"""
+
+import os
+import json
+import argparse
+from typing import Dict, List
+from tqdm import tqdm
+import time
+
+# Try to import API clients
+try:
+    from openai import OpenAI
+    OPENAI_AVAILABLE = True
+except ImportError:
+    OPENAI_AVAILABLE = False
+    print("Warning: OpenAI not installed. Use 'pip install openai'")
+
+try:
+    import anthropic
+    ANTHROPIC_AVAILABLE = True
+except ImportError:
+    ANTHROPIC_AVAILABLE = False
+    print("Warning: Anthropic not installed. Use 'pip install anthropic'")
+
+
+def gpt_evaluation_prompt_generator(prompt: str, response_A: str, response_B: str) -> str:
+    """Generate the evaluation prompt for comparing two responses."""
+    return f'''Given the history of multi-round chat, which response is more helpful?
+
+History:
+{prompt}
+
+Response A: {response_A}
+
+Response B: {response_B}
+
+FIRST provide a one-sentence comparison of the two responses and explain which you feel is more helpful. \
+SECOND, on a new line, state only "A" or "B" to indicate which response is more helpful. \
+Your response should use the format:
+
+Comparison: <one-sentence comparison and explanation>
+More helpful: <"A" or "B">'''
+
+
+def get_completion(msg: str, evaluator: str = 'claude', temp: float = 0.7) -> str:
+    """Get completion from the specified evaluator (GPT or Claude)."""
+    if evaluator == 'gpt':
+        if not OPENAI_AVAILABLE:
+            raise RuntimeError("OpenAI package not installed")
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY environment variable not set")
+
+        client = OpenAI(api_key=api_key)
+        response = client.chat.completions.create(
+            model='gpt-3.5-turbo',
+            messages=[
+                {"role": 'system', "content": 'You are a helpful assistant.'},
+                {'role': 'user', 'content': msg}
+            ],
+            temperature=temp,
+            top_p=1,
+        )
+        return response.choices[0].message.content
+
+    elif evaluator == 'claude':
+        if not ANTHROPIC_AVAILABLE:
+            raise RuntimeError("Anthropic package not installed")
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        if not api_key:
+            raise RuntimeError("ANTHROPIC_API_KEY environment variable not set")
+
+        client = anthropic.Anthropic(api_key=api_key)
+        response = client.messages.create(
+            model='claude-3-haiku-20240307',
+            system='You are a helpful assistant.',
+            messages=[{'role': 'user', 'content': msg}],
+            temperature=temp,
+            max_tokens=2048,
+            top_p=1,
+        )
+        return response.content[0].text
+
+    else:
+        raise ValueError(f"Unknown evaluator: {evaluator}")
+
+
+def extract_responses(exp_name: str, base_path: str = "exp_results") -> Dict[str, List[str]]:
+    """Extract responses from a generated response file."""
+    response_dict = {"prompt": [], "response": []}
+
+    # Try different possible file names
+    possible_files = [
+        os.path.join(base_path, exp_name, 'prob_test_gen_response.jsonl'),
+        os.path.join(base_path, f'gen_{exp_name}', 'prob_test_gen_response.jsonl'),
+    ]
+
+    response_file = None
+    for f in possible_files:
+        if os.path.exists(f):
+            response_file = f
+            break
+
+    if response_file is None:
+        raise FileNotFoundError(
+            f"Response file not found. Tried: {possible_files}"
+        )
+
+    with open(response_file, 'r') as f:
+        for line in f:
+            data = json.loads(line)
+            prompt = data['prompt'].strip('\n')
+            tmp_response = data['response'].strip('\n')
+
+            # Extract just the response part
+            if prompt in tmp_response:
+                response = tmp_response.split(prompt)[1].strip(' ')
+            elif 'Assistant: ' in tmp_response:
+                response = tmp_response.split('Assistant: ')[-1]
+            else:
+                response = tmp_response
+
+            response_dict["prompt"].append(prompt)
+            response_dict["response"].append(response)
+
+    return response_dict
+
+
+def evaluate_models(
+    model_a: str,
+    model_b: str,
+    evaluator: str = 'claude',
+    base_path: str = "exp_results",
+    output_dir: str = "eval_results",
+    max_response_len: int = 2000
+) -> Dict[str, float]:
+    """
+    Evaluate two models against each other using an LLM judge.
+
+    Args:
+        model_a: Experiment name for model A
+        model_b: Experiment name for model B
+        evaluator: Which LLM to use as judge ('gpt' or 'claude')
+        base_path: Base path for experiment results
+        output_dir: Directory to save evaluation logs
+        max_response_len: Maximum response length to evaluate
+
+    Returns:
+        Dictionary with evaluation results
+    """
+    print(f"Loading responses from {model_a}...")
+    res_a = extract_responses(model_a, base_path)
+
+    print(f"Loading responses from {model_b}...")
+    res_b = extract_responses(model_b, base_path)
+
+    assert len(res_a['prompt']) == len(res_b['prompt']), \
+        "Models have different number of responses"
+
+    # Create output directory
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Log file
+    log_file = os.path.join(output_dir, f"{model_a}_vs_{model_b}_{evaluator}.txt")
+
+    a_wins = 0
+    b_wins = 0
+    total = 0
+    skipped = 0
+
+    with open(log_file, 'a', encoding='utf-8') as f:
+        f.write(f"\n{'='*60}\n")
+        f.write(f"Evaluation: [{model_a}] vs [{model_b}]\n")
+        f.write(f"Evaluator: {evaluator}\n")
+        f.write(f"{'='*60}\n\n")
+
+        for i in tqdm(range(len(res_a['prompt'])), desc="Evaluating"):
+            assert res_a['prompt'][i] == res_b['prompt'][i], \
+                f"Prompt mismatch at index {i}"
+
+            prompt = res_a['prompt'][i]
+            resp_a = res_a['response'][i]
+            resp_b = res_b['response'][i]
+
+            # Skip very long responses
+            if len(resp_a) > max_response_len or len(resp_b) > max_response_len:
+                skipped += 1
+                continue
+
+            # Generate evaluation prompt and get response
+            eval_prompt = gpt_evaluation_prompt_generator(prompt, resp_a, resp_b)
+
+            try:
+                judge_response = get_completion(eval_prompt, evaluator)
+
+                # Record result
+                f.write(f"#======== Question {i}: {prompt[:40]}...\n")
+                f.write(f"Response A: {resp_a[:100]}...\n")
+                f.write(f"Response B: {resp_b[:100]}...\n")
+                f.write(f"Judge: {judge_response}\n\n")
+
+                # Extract winner
+                total += 1
+                answer = judge_response.split(': ')[-1].strip()
+                if answer == 'A':
+                    a_wins += 1
+                elif answer == 'B':
+                    b_wins += 1
+
+                # Small delay to avoid rate limiting
+                time.sleep(0.5)
+
+            except Exception as e:
+                f.write(f"#======== Error at Question {i}: {str(e)}\n\n")
+                continue
+
+        # Summary
+        if total > 0:
+            win_rate_a = a_wins / (a_wins + b_wins) if (a_wins + b_wins) > 0 else 0
+            win_rate_b = b_wins / (a_wins + b_wins) if (a_wins + b_wins) > 0 else 0
+
+            summary = f"""
+{'='*60}
+EVALUATION SUMMARY
+{'='*60}
+Model A ({model_a}): {a_wins} wins ({win_rate_a:.1%})
+Model B ({model_b}): {b_wins} wins ({win_rate_b:.1%})
+Total evaluated: {total}
+Skipped (too long): {skipped}
+{'='*60}
+"""
+            f.write(summary)
+            print(summary)
+
+            return {
+                'model_a': model_a,
+                'model_b': model_b,
+                'a_wins': a_wins,
+                'b_wins': b_wins,
+                'total': total,
+                'skipped': skipped,
+                'win_rate_a': win_rate_a,
+                'win_rate_b': win_rate_b
+            }
+
+    return {}
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Evaluate model responses using LLM judge')
+    parser.add_argument('--model_a', type=str, required=True,
+                        help='Experiment name for model A')
+    parser.add_argument('--model_b', type=str, required=True,
+                        help='Experiment name for model B')
+    parser.add_argument('--evaluator', type=str, default='claude',
+                        choices=['gpt', 'claude'],
+                        help='Which LLM to use as judge (default: claude)')
+    parser.add_argument('--base_path', type=str, default='exp_results',
+                        help='Base path for experiment results')
+    parser.add_argument('--output_dir', type=str, default='eval_results',
+                        help='Directory to save evaluation logs')
+
+    args = parser.parse_args()
+
+    # Change to src directory
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(os.path.join(script_dir, '..', 'src'))
+
+    evaluate_models(
+        model_a=args.model_a,
+        model_b=args.model_b,
+        evaluator=args.evaluator,
+        base_path=args.base_path,
+        output_dir=args.output_dir
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/generate_inference_samples.sh
+++ b/scripts/generate_inference_samples.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# ============================================================================
+# Inference Sample Generation Script
+# ============================================================================
+# This script generates inference samples for evaluation from trained models.
+# It generates responses for prob_train_gen, prob_test_gen, prob_train_selfr,
+# and prob_test_selfr datasets.
+# ============================================================================
+
+set -e
+
+# Default model to generate from - can be overridden by command line argument
+MODEL=${1:-"qwen18"}
+CHECKPOINT=${2:-"qwen18_dpo_base_ep6"}
+EPOCH=${3:-""}  # Optional: specify epoch like "epoch_2", "epoch_4", "epoch_6"
+
+# GPU Configuration
+export CUDA_VISIBLE_DEVICES=0
+
+# Navigate to source directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}/../src"
+
+# Determine checkpoint path
+if [ -n "${EPOCH}" ]; then
+    ARCHIVE="${CHECKPOINT}/${EPOCH}"
+    EXP_NAME="gen_${CHECKPOINT}_${EPOCH}"
+else
+    ARCHIVE="${CHECKPOINT}"
+    EXP_NAME="gen_${CHECKPOINT}"
+fi
+
+echo "=============================================="
+echo "Inference Sample Generation"
+echo "=============================================="
+echo "Model: ${MODEL}"
+echo "Checkpoint: ${ARCHIVE}"
+echo "Output: exp_results/${EXP_NAME}"
+echo "GPU: ${CUDA_VISIBLE_DEVICES}"
+echo "=============================================="
+
+# Check if checkpoint exists
+if [ ! -f "exp_results/${ARCHIVE}/policy.pt" ]; then
+    echo "ERROR: Checkpoint not found at exp_results/${ARCHIVE}/policy.pt"
+    exit 1
+fi
+
+# Create output directory
+mkdir -p "exp_results/${EXP_NAME}"
+
+# Run inference generation
+python -u gen_inference_samples.py \
+    model=${MODEL} \
+    model.archive=${ARCHIVE} \
+    exp_name=${EXP_NAME} \
+    trainer=BasicTrainer \
+    max_length=400 \
+    wandb.enabled=false
+
+echo ""
+echo "=============================================="
+echo "Inference Generation Complete!"
+echo "=============================================="
+echo "Generated files saved to: exp_results/${EXP_NAME}/"
+echo "  - prob_train_gen_response.jsonl"
+echo "  - prob_test_gen_response.jsonl"
+echo "  - prob_train_selfr_response.jsonl"
+echo "  - prob_test_selfr_response.jsonl"
+echo ""

--- a/scripts/run_all_experiments.sh
+++ b/scripts/run_all_experiments.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# ============================================================================
+# Master Experiment Runner Script
+# ============================================================================
+# This script runs all experiments in sequence:
+# 1. SFT Base (2 epochs, 10000 examples)
+# 2. SFT Extend (2 epochs, 10000 examples)
+# 3. DPO Base (6 epochs with checkpoints at 2, 4, 6)
+# 4. DPO Extend (6 epochs with checkpoints at 2, 4, 6)
+# 5. Generate inference samples for all models
+# 6. (Optional) Run evaluation
+# ============================================================================
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "=============================================="
+echo "Learning Dynamics LLM - Full Experiment Run"
+echo "=============================================="
+echo "Start time: $(date)"
+echo ""
+
+# Create logs directory
+mkdir -p "${SCRIPT_DIR}/../logs"
+
+# Step 1: Train SFT Base
+echo "=============================================="
+echo "Step 1/5: Training SFT Base..."
+echo "=============================================="
+bash "${SCRIPT_DIR}/train_sft_base.sh" 2>&1 | tee "${SCRIPT_DIR}/../logs/sft_base.log"
+echo "SFT Base completed at $(date)"
+echo ""
+
+# Step 2: Train SFT Extend
+echo "=============================================="
+echo "Step 2/5: Training SFT Extend..."
+echo "=============================================="
+bash "${SCRIPT_DIR}/train_sft_extend.sh" 2>&1 | tee "${SCRIPT_DIR}/../logs/sft_extend.log"
+echo "SFT Extend completed at $(date)"
+echo ""
+
+# Step 3: Train DPO Base
+echo "=============================================="
+echo "Step 3/5: Training DPO Base..."
+echo "=============================================="
+bash "${SCRIPT_DIR}/train_dpo_base.sh" 2>&1 | tee "${SCRIPT_DIR}/../logs/dpo_base.log"
+echo "DPO Base completed at $(date)"
+echo ""
+
+# Step 4: Train DPO Extend
+echo "=============================================="
+echo "Step 4/5: Training DPO Extend..."
+echo "=============================================="
+bash "${SCRIPT_DIR}/train_dpo_extend.sh" 2>&1 | tee "${SCRIPT_DIR}/../logs/dpo_extend.log"
+echo "DPO Extend completed at $(date)"
+echo ""
+
+# Step 5: Generate inference samples
+echo "=============================================="
+echo "Step 5/5: Generating Inference Samples..."
+echo "=============================================="
+
+# Generate for SFT models
+bash "${SCRIPT_DIR}/generate_inference_samples.sh" qwen18 qwen18_sft_base_ep2 2>&1 | tee -a "${SCRIPT_DIR}/../logs/inference_gen.log"
+bash "${SCRIPT_DIR}/generate_inference_samples.sh" qwen18 qwen18_sft_extend_ep2 2>&1 | tee -a "${SCRIPT_DIR}/../logs/inference_gen.log"
+
+# Generate for DPO models at different epochs
+for EPOCH in epoch_2 epoch_4 epoch_6; do
+    bash "${SCRIPT_DIR}/generate_inference_samples.sh" qwen18 qwen18_dpo_base_ep6 ${EPOCH} 2>&1 | tee -a "${SCRIPT_DIR}/../logs/inference_gen.log"
+    bash "${SCRIPT_DIR}/generate_inference_samples.sh" qwen18 qwen18_dpo_extend_ep6 ${EPOCH} 2>&1 | tee -a "${SCRIPT_DIR}/../logs/inference_gen.log"
+done
+
+# Generate for final DPO models
+bash "${SCRIPT_DIR}/generate_inference_samples.sh" qwen18 qwen18_dpo_base_ep6 2>&1 | tee -a "${SCRIPT_DIR}/../logs/inference_gen.log"
+bash "${SCRIPT_DIR}/generate_inference_samples.sh" qwen18 qwen18_dpo_extend_ep6 2>&1 | tee -a "${SCRIPT_DIR}/../logs/inference_gen.log"
+
+echo ""
+echo "=============================================="
+echo "All Experiments Complete!"
+echo "=============================================="
+echo "End time: $(date)"
+echo ""
+echo "Summary of generated checkpoints:"
+echo "  - exp_results/qwen18_sft_base_ep2/"
+echo "  - exp_results/qwen18_sft_extend_ep2/"
+echo "  - exp_results/qwen18_dpo_base_ep6/epoch_2/"
+echo "  - exp_results/qwen18_dpo_base_ep6/epoch_4/"
+echo "  - exp_results/qwen18_dpo_base_ep6/epoch_6/"
+echo "  - exp_results/qwen18_dpo_base_ep6/"
+echo "  - exp_results/qwen18_dpo_extend_ep6/epoch_2/"
+echo "  - exp_results/qwen18_dpo_extend_ep6/epoch_4/"
+echo "  - exp_results/qwen18_dpo_extend_ep6/epoch_6/"
+echo "  - exp_results/qwen18_dpo_extend_ep6/"
+echo ""
+echo "To run evaluation, use:"
+echo "  python ${SCRIPT_DIR}/evaluate_models.py --model_a qwen18_dpo_base_ep6 --model_b qwen18_dpo_extend_ep6"
+echo ""

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# ============================================================================
+# Environment Setup Script for Learning Dynamics of LLM Finetuning
+# ============================================================================
+# Target System: NVIDIA RTX PRO 6000 (97GB VRAM) with CUDA 13.0
+# This script creates a conda environment optimized for your hardware.
+# ============================================================================
+
+set -e  # Exit on error
+
+echo "=============================================="
+echo "Learning Dynamics LLM - Environment Setup"
+echo "=============================================="
+
+# Configuration
+ENV_NAME="learntune"
+PYTHON_VERSION="3.10"
+
+# Check if conda is available
+if ! command -v conda &> /dev/null; then
+    echo "ERROR: conda is not installed or not in PATH"
+    echo "Please install Miniconda or Anaconda first:"
+    echo "  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh"
+    echo "  bash Miniconda3-latest-Linux-x86_64.sh"
+    exit 1
+fi
+
+# Check CUDA availability
+echo ""
+echo "Checking CUDA..."
+if command -v nvidia-smi &> /dev/null; then
+    nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv
+else
+    echo "WARNING: nvidia-smi not found. GPU support may not work."
+fi
+
+# Create conda environment
+echo ""
+echo "Creating conda environment: ${ENV_NAME}"
+conda create -n ${ENV_NAME} python=${PYTHON_VERSION} -y
+
+# Activate environment
+echo ""
+echo "Activating environment..."
+source $(conda info --base)/etc/profile.d/conda.sh
+conda activate ${ENV_NAME}
+
+# Install PyTorch with CUDA support
+# For CUDA 12.x (compatible with CUDA 13.0 driver)
+echo ""
+echo "Installing PyTorch with CUDA 12.1 support..."
+pip install torch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 --index-url https://download.pytorch.org/whl/cu121
+
+# Install core dependencies
+echo ""
+echo "Installing core dependencies..."
+pip install transformers==4.36.2
+pip install datasets==2.16.1
+pip install tokenizers==0.15.0
+pip install accelerate==0.25.0
+
+# Install additional dependencies
+echo ""
+echo "Installing additional dependencies..."
+pip install numpy
+pip install tqdm
+pip install wandb
+pip install hydra-core==1.3.2
+pip install omegaconf
+pip install beautifulsoup4
+pip install fsspec
+pip install ipykernel
+pip install jupyter
+pip install matplotlib
+pip install seaborn
+pip install pandas
+
+# Install tensor-parallel (optional, for multi-GPU tensor parallelism)
+echo ""
+echo "Installing tensor-parallel..."
+pip install tensor-parallel
+
+# Install flash-attention for faster training (optional but recommended)
+echo ""
+echo "Installing flash-attention (this may take a while)..."
+pip install ninja packaging
+pip install flash-attn --no-build-isolation || echo "Warning: flash-attn installation failed. Continuing without it."
+
+# Verify installation
+echo ""
+echo "=============================================="
+echo "Verifying Installation..."
+echo "=============================================="
+
+python -c "
+import torch
+print(f'PyTorch version: {torch.__version__}')
+print(f'CUDA available: {torch.cuda.is_available()}')
+if torch.cuda.is_available():
+    print(f'CUDA version: {torch.version.cuda}')
+    print(f'GPU count: {torch.cuda.device_count()}')
+    for i in range(torch.cuda.device_count()):
+        print(f'  GPU {i}: {torch.cuda.get_device_name(i)}')
+        print(f'    Memory: {torch.cuda.get_device_properties(i).total_memory / 1e9:.1f} GB')
+"
+
+python -c "import transformers; print(f'Transformers version: {transformers.__version__}')"
+python -c "import datasets; print(f'Datasets version: {datasets.__version__}')"
+python -c "import hydra; print(f'Hydra version: {hydra.__version__}')"
+python -c "import wandb; print(f'Wandb version: {wandb.__version__}')"
+
+echo ""
+echo "=============================================="
+echo "Environment setup complete!"
+echo "=============================================="
+echo ""
+echo "To activate the environment, run:"
+echo "  conda activate ${ENV_NAME}"
+echo ""
+echo "To test GPU memory allocation, run:"
+echo "  python -c \"import torch; x = torch.zeros(1000, 1000, 1000).cuda(); print('GPU memory test passed!')\""
+echo ""

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -2,14 +2,16 @@
 # ============================================================================
 # Environment Setup Script for Learning Dynamics of LLM Finetuning
 # ============================================================================
-# Target System: NVIDIA RTX PRO 6000 (97GB VRAM) with CUDA 13.0
-# This script creates a conda environment optimized for your hardware.
+# Target System: NVIDIA RTX PRO 6000 Blackwell (sm_120) with CUDA 13.0
+# This script creates a conda environment optimized for Blackwell GPUs.
 # ============================================================================
 
 set -e  # Exit on error
 
 echo "=============================================="
 echo "Learning Dynamics LLM - Environment Setup"
+echo "=============================================="
+echo "Detected: NVIDIA RTX PRO 6000 Blackwell (sm_120)"
 echo "=============================================="
 
 # Configuration
@@ -34,6 +36,14 @@ else
     echo "WARNING: nvidia-smi not found. GPU support may not work."
 fi
 
+# Remove existing environment if it exists
+echo ""
+echo "Checking for existing environment..."
+if conda env list | grep -q "^${ENV_NAME} "; then
+    echo "Removing existing ${ENV_NAME} environment..."
+    conda env remove -n ${ENV_NAME} -y
+fi
+
 # Create conda environment
 echo ""
 echo "Creating conda environment: ${ENV_NAME}"
@@ -45,24 +55,44 @@ echo "Activating environment..."
 source $(conda info --base)/etc/profile.d/conda.sh
 conda activate ${ENV_NAME}
 
-# Install PyTorch with CUDA support
-# For CUDA 12.x (compatible with CUDA 13.0 driver)
+# CRITICAL: Install NumPy < 2.0 first to avoid compatibility issues
 echo ""
-echo "Installing PyTorch with CUDA 12.1 support..."
-pip install torch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 --index-url https://download.pytorch.org/whl/cu121
+echo "Installing NumPy < 2.0 (required for PyTorch compatibility)..."
+pip install "numpy<2.0"
+
+# Install PyTorch with CUDA 12.6 support for Blackwell (sm_120)
+# PyTorch 2.5+ with CUDA 12.6 is required for Blackwell GPUs
+echo ""
+echo "Installing PyTorch 2.5+ with CUDA 12.6 support (for Blackwell sm_120)..."
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
+
+# Verify PyTorch CUDA support for Blackwell
+echo ""
+echo "Verifying PyTorch Blackwell support..."
+python -c "
+import torch
+print(f'PyTorch version: {torch.__version__}')
+print(f'CUDA available: {torch.cuda.is_available()}')
+if torch.cuda.is_available():
+    print(f'CUDA version: {torch.version.cuda}')
+    for i in range(torch.cuda.device_count()):
+        props = torch.cuda.get_device_properties(i)
+        print(f'GPU {i}: {props.name}')
+        print(f'  Compute capability: {props.major}.{props.minor}')
+        print(f'  Memory: {props.total_memory / 1e9:.1f} GB')
+"
 
 # Install core dependencies
 echo ""
 echo "Installing core dependencies..."
-pip install transformers==4.36.2
+pip install transformers==4.46.0
 pip install datasets==2.16.1
-pip install tokenizers==0.15.0
-pip install accelerate==0.25.0
+pip install tokenizers==0.20.0
+pip install accelerate==0.34.0
 
 # Install additional dependencies
 echo ""
 echo "Installing additional dependencies..."
-pip install numpy
 pip install tqdm
 pip install wandb
 pip install hydra-core==1.3.2
@@ -80,7 +110,7 @@ echo ""
 echo "Installing tensor-parallel..."
 pip install tensor-parallel
 
-# Install flash-attention for faster training (optional but recommended)
+# Install flash-attention for faster training (optional but recommended for Blackwell)
 echo ""
 echo "Installing flash-attention (this may take a while)..."
 pip install ninja packaging
@@ -100,10 +130,19 @@ if torch.cuda.is_available():
     print(f'CUDA version: {torch.version.cuda}')
     print(f'GPU count: {torch.cuda.device_count()}')
     for i in range(torch.cuda.device_count()):
-        print(f'  GPU {i}: {torch.cuda.get_device_name(i)}')
-        print(f'    Memory: {torch.cuda.get_device_properties(i).total_memory / 1e9:.1f} GB')
+        props = torch.cuda.get_device_properties(i)
+        print(f'  GPU {i}: {props.name}')
+        print(f'    Compute capability: {props.major}.{props.minor}')
+        print(f'    Memory: {props.total_memory / 1e9:.1f} GB')
+    # Test CUDA tensor allocation
+    try:
+        x = torch.zeros(100, 100).cuda()
+        print('  CUDA tensor test: PASSED')
+    except Exception as e:
+        print(f'  CUDA tensor test: FAILED - {e}')
 "
 
+python -c "import numpy; print(f'NumPy version: {numpy.__version__}')"
 python -c "import transformers; print(f'Transformers version: {transformers.__version__}')"
 python -c "import datasets; print(f'Datasets version: {datasets.__version__}')"
 python -c "import hydra; print(f'Hydra version: {hydra.__version__}')"
@@ -114,7 +153,7 @@ echo "=============================================="
 echo "Environment setup complete!"
 echo "=============================================="
 echo ""
-echo "To activate the environment, run:"
+echo "IMPORTANT: To activate the environment, run:"
 echo "  conda activate ${ENV_NAME}"
 echo ""
 echo "To test GPU memory allocation, run:"

--- a/scripts/setup_environment.sh
+++ b/scripts/setup_environment.sh
@@ -60,11 +60,11 @@ echo ""
 echo "Installing NumPy < 2.0 (required for PyTorch compatibility)..."
 pip install "numpy<2.0"
 
-# Install PyTorch with CUDA 12.6 support for Blackwell (sm_120)
-# PyTorch 2.5+ with CUDA 12.6 is required for Blackwell GPUs
+# Install PyTorch with CUDA 12.8 support for Blackwell (sm_120)
+# Blackwell GPUs require PyTorch nightly with CUDA 12.8+
 echo ""
-echo "Installing PyTorch 2.5+ with CUDA 12.6 support (for Blackwell sm_120)..."
-pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126
+echo "Installing PyTorch nightly with CUDA 12.8 support (for Blackwell sm_120)..."
+pip install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128
 
 # Verify PyTorch CUDA support for Blackwell
 echo ""
@@ -82,13 +82,13 @@ if torch.cuda.is_available():
         print(f'  Memory: {props.total_memory / 1e9:.1f} GB')
 "
 
-# Install core dependencies
+# Install core dependencies (latest versions for PyTorch nightly compatibility)
 echo ""
 echo "Installing core dependencies..."
-pip install transformers==4.46.0
-pip install datasets==2.16.1
-pip install tokenizers==0.20.0
-pip install accelerate==0.34.0
+pip install transformers
+pip install datasets
+pip install tokenizers
+pip install accelerate
 
 # Install additional dependencies
 echo ""

--- a/scripts/train_dpo_base.sh
+++ b/scripts/train_dpo_base.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# ============================================================================
+# DPO Base Training Script for Qwen 1.8B
+# ============================================================================
+# This script trains DPO on top of the base SFT model
+# Configuration: 6 epochs with checkpoints at epochs 2, 4, 6
+# ============================================================================
+
+set -e
+
+# Configuration
+MODEL="qwen18"
+SFT_CHECKPOINT="qwen18_sft_base_ep2"  # The SFT checkpoint to load
+EXP_NAME="qwen18_dpo_base_ep6"
+N_EPOCHS=6
+N_EXAMPLES=30000  # 5000 examples per epoch
+BATCH_SIZE=2  # Smaller batch for DPO (needs more memory for reference model)
+EVAL_EVERY=1000
+LR="5e-7"
+BETA=0.1  # DPO beta parameter
+SAVE_EPOCHS="2,4,6"  # Epochs at which to save checkpoints
+
+# GPU Configuration
+export CUDA_VISIBLE_DEVICES=0
+
+# Navigate to source directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}/../src"
+
+echo "=============================================="
+echo "DPO Base Training - Qwen 1.8B"
+echo "=============================================="
+echo "Model: ${MODEL}"
+echo "SFT Checkpoint: ${SFT_CHECKPOINT}"
+echo "Experiment: ${EXP_NAME}"
+echo "Epochs: ${N_EPOCHS}"
+echo "Examples: ${N_EXAMPLES}"
+echo "Batch Size: ${BATCH_SIZE}"
+echo "DPO Beta: ${BETA}"
+echo "Save at epochs: ${SAVE_EPOCHS}"
+echo "GPU: ${CUDA_VISIBLE_DEVICES}"
+echo "=============================================="
+
+# Check if SFT checkpoint exists
+if [ ! -f "exp_results/${SFT_CHECKPOINT}/policy.pt" ]; then
+    echo "ERROR: SFT checkpoint not found at exp_results/${SFT_CHECKPOINT}/policy.pt"
+    echo "Please run train_sft_base.sh first."
+    exit 1
+fi
+
+# Run training
+python -u train.py \
+    loss=dpo \
+    loss.beta=${BETA} \
+    model=${MODEL} \
+    model.archive=${SFT_CHECKPOINT} \
+    exp_name=${EXP_NAME} \
+    trainer=BasicTrainer \
+    train_split=train_dpo \
+    n_epochs=${N_EPOCHS} \
+    n_examples=${N_EXAMPLES} \
+    batch_size=${BATCH_SIZE} \
+    eval_every=${EVAL_EVERY} \
+    lr=${LR} \
+    save_ckp=true \
+    save_epochs="${SAVE_EPOCHS}" \
+    fine_evaluation=true \
+    wandb.enabled=true \
+    wandb.project="learntune_replication"
+
+echo ""
+echo "=============================================="
+echo "DPO Base Training Complete!"
+echo "=============================================="
+echo "Checkpoints saved to:"
+echo "  - exp_results/${EXP_NAME}/epoch_2/"
+echo "  - exp_results/${EXP_NAME}/epoch_4/"
+echo "  - exp_results/${EXP_NAME}/epoch_6/"
+echo "  - exp_results/${EXP_NAME}/ (final)"
+echo ""

--- a/scripts/train_dpo_base.sh
+++ b/scripts/train_dpo_base.sh
@@ -14,7 +14,8 @@ SFT_CHECKPOINT="qwen18_sft_base_ep2"  # The SFT checkpoint to load
 EXP_NAME="qwen18_dpo_base_ep6"
 N_EPOCHS=6
 N_EXAMPLES=30000  # 5000 examples per epoch
-BATCH_SIZE=2  # Smaller batch for DPO (needs more memory for reference model)
+BATCH_SIZE=16  # DPO needs policy + reference model, but 97GB VRAM is plenty
+GRADIENT_ACCUMULATION_STEPS=2  # Effective batch = 16 * 2 = 32
 EVAL_EVERY=1000
 LR="5e-7"
 BETA=0.1  # DPO beta parameter
@@ -36,6 +37,8 @@ echo "Experiment: ${EXP_NAME}"
 echo "Epochs: ${N_EPOCHS}"
 echo "Examples: ${N_EXAMPLES}"
 echo "Batch Size: ${BATCH_SIZE}"
+echo "Gradient Accumulation: ${GRADIENT_ACCUMULATION_STEPS}"
+echo "Effective Batch Size: $((BATCH_SIZE * GRADIENT_ACCUMULATION_STEPS))"
 echo "DPO Beta: ${BETA}"
 echo "Save at epochs: ${SAVE_EPOCHS}"
 echo "GPU: ${CUDA_VISIBLE_DEVICES}"
@@ -60,6 +63,7 @@ python -u train.py \
     n_epochs=${N_EPOCHS} \
     n_examples=${N_EXAMPLES} \
     batch_size=${BATCH_SIZE} \
+    gradient_accumulation_steps=${GRADIENT_ACCUMULATION_STEPS} \
     eval_every=${EVAL_EVERY} \
     lr=${LR} \
     save_ckp=true \

--- a/scripts/train_dpo_base.sh
+++ b/scripts/train_dpo_base.sh
@@ -14,8 +14,8 @@ SFT_CHECKPOINT="qwen18_sft_base_ep2"  # The SFT checkpoint to load
 EXP_NAME="qwen18_dpo_base_ep6"
 N_EPOCHS=6
 N_EXAMPLES=30000  # 5000 examples per epoch
-BATCH_SIZE=16  # DPO needs policy + reference model, but 97GB VRAM is plenty
-GRADIENT_ACCUMULATION_STEPS=2  # Effective batch = 16 * 2 = 32
+BATCH_SIZE=32  # 97GB VRAM easily handles both policy + reference model
+GRADIENT_ACCUMULATION_STEPS=1  # Effective batch = 32
 EVAL_EVERY=1000
 LR="5e-7"
 BETA=0.1  # DPO beta parameter

--- a/scripts/train_dpo_extend.sh
+++ b/scripts/train_dpo_extend.sh
@@ -14,8 +14,8 @@ SFT_CHECKPOINT="qwen18_sft_extend_ep2"  # The SFT extend checkpoint to load
 EXP_NAME="qwen18_dpo_extend_ep6"
 N_EPOCHS=6
 N_EXAMPLES=30000  # 5000 examples per epoch
-BATCH_SIZE=16  # DPO needs policy + reference model, but 97GB VRAM is plenty
-GRADIENT_ACCUMULATION_STEPS=2  # Effective batch = 16 * 2 = 32
+BATCH_SIZE=32  # 97GB VRAM easily handles both policy + reference model
+GRADIENT_ACCUMULATION_STEPS=1  # Effective batch = 32
 EVAL_EVERY=1000
 LR="5e-7"
 BETA=0.1  # DPO beta parameter

--- a/scripts/train_dpo_extend.sh
+++ b/scripts/train_dpo_extend.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# ============================================================================
+# DPO Extend Training Script for Qwen 1.8B
+# ============================================================================
+# This script trains DPO on top of the extended SFT model
+# Configuration: 6 epochs with checkpoints at epochs 2, 4, 6
+# ============================================================================
+
+set -e
+
+# Configuration
+MODEL="qwen18"
+SFT_CHECKPOINT="qwen18_sft_extend_ep2"  # The SFT extend checkpoint to load
+EXP_NAME="qwen18_dpo_extend_ep6"
+N_EPOCHS=6
+N_EXAMPLES=30000  # 5000 examples per epoch
+BATCH_SIZE=2  # Smaller batch for DPO (needs more memory for reference model)
+EVAL_EVERY=1000
+LR="5e-7"
+BETA=0.1  # DPO beta parameter
+SAVE_EPOCHS="2,4,6"  # Epochs at which to save checkpoints
+
+# GPU Configuration
+export CUDA_VISIBLE_DEVICES=1
+
+# Navigate to source directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}/../src"
+
+echo "=============================================="
+echo "DPO Extend Training - Qwen 1.8B"
+echo "=============================================="
+echo "Model: ${MODEL}"
+echo "SFT Checkpoint: ${SFT_CHECKPOINT}"
+echo "Experiment: ${EXP_NAME}"
+echo "Epochs: ${N_EPOCHS}"
+echo "Examples: ${N_EXAMPLES}"
+echo "Batch Size: ${BATCH_SIZE}"
+echo "DPO Beta: ${BETA}"
+echo "Save at epochs: ${SAVE_EPOCHS}"
+echo "GPU: ${CUDA_VISIBLE_DEVICES}"
+echo "=============================================="
+
+# Check if SFT checkpoint exists
+if [ ! -f "exp_results/${SFT_CHECKPOINT}/policy.pt" ]; then
+    echo "ERROR: SFT checkpoint not found at exp_results/${SFT_CHECKPOINT}/policy.pt"
+    echo "Please run train_sft_extend.sh first."
+    exit 1
+fi
+
+# Run training
+python -u train.py \
+    loss=dpo \
+    loss.beta=${BETA} \
+    model=${MODEL} \
+    model.archive=${SFT_CHECKPOINT} \
+    exp_name=${EXP_NAME} \
+    trainer=BasicTrainer \
+    train_split=train_dpo \
+    n_epochs=${N_EPOCHS} \
+    n_examples=${N_EXAMPLES} \
+    batch_size=${BATCH_SIZE} \
+    eval_every=${EVAL_EVERY} \
+    lr=${LR} \
+    save_ckp=true \
+    save_epochs="${SAVE_EPOCHS}" \
+    fine_evaluation=true \
+    wandb.enabled=true \
+    wandb.project="learntune_replication"
+
+echo ""
+echo "=============================================="
+echo "DPO Extend Training Complete!"
+echo "=============================================="
+echo "Checkpoints saved to:"
+echo "  - exp_results/${EXP_NAME}/epoch_2/"
+echo "  - exp_results/${EXP_NAME}/epoch_4/"
+echo "  - exp_results/${EXP_NAME}/epoch_6/"
+echo "  - exp_results/${EXP_NAME}/ (final)"
+echo ""

--- a/scripts/train_dpo_extend.sh
+++ b/scripts/train_dpo_extend.sh
@@ -14,7 +14,8 @@ SFT_CHECKPOINT="qwen18_sft_extend_ep2"  # The SFT extend checkpoint to load
 EXP_NAME="qwen18_dpo_extend_ep6"
 N_EPOCHS=6
 N_EXAMPLES=30000  # 5000 examples per epoch
-BATCH_SIZE=2  # Smaller batch for DPO (needs more memory for reference model)
+BATCH_SIZE=16  # DPO needs policy + reference model, but 97GB VRAM is plenty
+GRADIENT_ACCUMULATION_STEPS=2  # Effective batch = 16 * 2 = 32
 EVAL_EVERY=1000
 LR="5e-7"
 BETA=0.1  # DPO beta parameter
@@ -36,6 +37,8 @@ echo "Experiment: ${EXP_NAME}"
 echo "Epochs: ${N_EPOCHS}"
 echo "Examples: ${N_EXAMPLES}"
 echo "Batch Size: ${BATCH_SIZE}"
+echo "Gradient Accumulation: ${GRADIENT_ACCUMULATION_STEPS}"
+echo "Effective Batch Size: $((BATCH_SIZE * GRADIENT_ACCUMULATION_STEPS))"
 echo "DPO Beta: ${BETA}"
 echo "Save at epochs: ${SAVE_EPOCHS}"
 echo "GPU: ${CUDA_VISIBLE_DEVICES}"
@@ -60,6 +63,7 @@ python -u train.py \
     n_epochs=${N_EPOCHS} \
     n_examples=${N_EXAMPLES} \
     batch_size=${BATCH_SIZE} \
+    gradient_accumulation_steps=${GRADIENT_ACCUMULATION_STEPS} \
     eval_every=${EVAL_EVERY} \
     lr=${LR} \
     save_ckp=true \

--- a/scripts/train_sft_base.sh
+++ b/scripts/train_sft_base.sh
@@ -13,7 +13,8 @@ MODEL="qwen18"
 EXP_NAME="qwen18_sft_base_ep2"
 N_EPOCHS=2
 N_EXAMPLES=10000
-BATCH_SIZE=4
+BATCH_SIZE=32
+GRADIENT_ACCUMULATION_STEPS=1  # Effective batch = BATCH_SIZE * GRAD_ACCUM = 32
 EVAL_EVERY=500
 LR="5e-7"
 
@@ -32,6 +33,8 @@ echo "Experiment: ${EXP_NAME}"
 echo "Epochs: ${N_EPOCHS}"
 echo "Examples: ${N_EXAMPLES}"
 echo "Batch Size: ${BATCH_SIZE}"
+echo "Gradient Accumulation: ${GRADIENT_ACCUMULATION_STEPS}"
+echo "Effective Batch Size: $((BATCH_SIZE * GRADIENT_ACCUMULATION_STEPS))"
 echo "GPU: ${CUDA_VISIBLE_DEVICES}"
 echo "=============================================="
 
@@ -44,6 +47,7 @@ python -u train.py \
     n_epochs=${N_EPOCHS} \
     n_examples=${N_EXAMPLES} \
     batch_size=${BATCH_SIZE} \
+    gradient_accumulation_steps=${GRADIENT_ACCUMULATION_STEPS} \
     eval_every=${EVAL_EVERY} \
     lr=${LR} \
     save_ckp=true \

--- a/scripts/train_sft_base.sh
+++ b/scripts/train_sft_base.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# ============================================================================
+# SFT Base Training Script for Qwen 1.8B
+# ============================================================================
+# This script trains the base SFT model using the standard train_dpo split
+# Configuration: 2 epochs, 10000 examples
+# ============================================================================
+
+set -e
+
+# Configuration
+MODEL="qwen18"
+EXP_NAME="qwen18_sft_base_ep2"
+N_EPOCHS=2
+N_EXAMPLES=10000
+BATCH_SIZE=4
+EVAL_EVERY=500
+LR="5e-7"
+
+# GPU Configuration - Use GPU 0 or 1 (they are free based on nvidia-smi)
+export CUDA_VISIBLE_DEVICES=0
+
+# Navigate to source directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}/../src"
+
+echo "=============================================="
+echo "SFT Base Training - Qwen 1.8B"
+echo "=============================================="
+echo "Model: ${MODEL}"
+echo "Experiment: ${EXP_NAME}"
+echo "Epochs: ${N_EPOCHS}"
+echo "Examples: ${N_EXAMPLES}"
+echo "Batch Size: ${BATCH_SIZE}"
+echo "GPU: ${CUDA_VISIBLE_DEVICES}"
+echo "=============================================="
+
+# Run training
+python -u train.py \
+    model=${MODEL} \
+    exp_name=${EXP_NAME} \
+    trainer=BasicTrainer \
+    train_split=train_dpo \
+    n_epochs=${N_EPOCHS} \
+    n_examples=${N_EXAMPLES} \
+    batch_size=${BATCH_SIZE} \
+    eval_every=${EVAL_EVERY} \
+    lr=${LR} \
+    save_ckp=true \
+    fine_evaluation=true \
+    wandb.enabled=true \
+    wandb.project="learntune_replication"
+
+echo ""
+echo "=============================================="
+echo "SFT Base Training Complete!"
+echo "=============================================="
+echo "Checkpoint saved to: exp_results/${EXP_NAME}"
+echo ""

--- a/scripts/train_sft_extend.sh
+++ b/scripts/train_sft_extend.sh
@@ -13,7 +13,8 @@ MODEL="qwen18"
 EXP_NAME="qwen18_sft_extend_ep2"
 N_EPOCHS=2
 N_EXAMPLES=10000
-BATCH_SIZE=4
+BATCH_SIZE=32
+GRADIENT_ACCUMULATION_STEPS=1  # Effective batch = BATCH_SIZE * GRAD_ACCUM = 32
 EVAL_EVERY=500
 LR="5e-7"
 
@@ -33,6 +34,8 @@ echo "Train Split: train_sft_extend"
 echo "Epochs: ${N_EPOCHS}"
 echo "Examples: ${N_EXAMPLES}"
 echo "Batch Size: ${BATCH_SIZE}"
+echo "Gradient Accumulation: ${GRADIENT_ACCUMULATION_STEPS}"
+echo "Effective Batch Size: $((BATCH_SIZE * GRADIENT_ACCUMULATION_STEPS))"
 echo "GPU: ${CUDA_VISIBLE_DEVICES}"
 echo "=============================================="
 
@@ -45,6 +48,7 @@ python -u train.py \
     n_epochs=${N_EPOCHS} \
     n_examples=${N_EXAMPLES} \
     batch_size=${BATCH_SIZE} \
+    gradient_accumulation_steps=${GRADIENT_ACCUMULATION_STEPS} \
     eval_every=${EVAL_EVERY} \
     lr=${LR} \
     save_ckp=true \

--- a/scripts/train_sft_extend.sh
+++ b/scripts/train_sft_extend.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# ============================================================================
+# SFT Extend Training Script for Qwen 1.8B
+# ============================================================================
+# This script trains the extended SFT model using the train_sft_extend split
+# Configuration: 2 epochs, 10000 examples
+# ============================================================================
+
+set -e
+
+# Configuration
+MODEL="qwen18"
+EXP_NAME="qwen18_sft_extend_ep2"
+N_EPOCHS=2
+N_EXAMPLES=10000
+BATCH_SIZE=4
+EVAL_EVERY=500
+LR="5e-7"
+
+# GPU Configuration - Use GPU 1
+export CUDA_VISIBLE_DEVICES=1
+
+# Navigate to source directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}/../src"
+
+echo "=============================================="
+echo "SFT Extend Training - Qwen 1.8B"
+echo "=============================================="
+echo "Model: ${MODEL}"
+echo "Experiment: ${EXP_NAME}"
+echo "Train Split: train_sft_extend"
+echo "Epochs: ${N_EPOCHS}"
+echo "Examples: ${N_EXAMPLES}"
+echo "Batch Size: ${BATCH_SIZE}"
+echo "GPU: ${CUDA_VISIBLE_DEVICES}"
+echo "=============================================="
+
+# Run training
+python -u train.py \
+    model=${MODEL} \
+    exp_name=${EXP_NAME} \
+    trainer=BasicTrainer \
+    train_split=train_sft_extend \
+    n_epochs=${N_EPOCHS} \
+    n_examples=${N_EXAMPLES} \
+    batch_size=${BATCH_SIZE} \
+    eval_every=${EVAL_EVERY} \
+    lr=${LR} \
+    save_ckp=true \
+    fine_evaluation=true \
+    wandb.enabled=true \
+    wandb.project="learntune_replication"
+
+echo ""
+echo "=============================================="
+echo "SFT Extend Training Complete!"
+echo "=============================================="
+echo "Checkpoint saved to: exp_results/${EXP_NAME}"
+echo ""

--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -33,6 +33,10 @@ wandb:
   project: "P5_5_dynamics"
 
 save_ckp: false
+
+# Epochs at which to save intermediate checkpoints (comma-separated or list)
+# e.g., save_epochs: "2,4,6" or save_epochs: [2, 4, 6]
+save_epochs: null
 # to create the local run directory and cache models/datasets,
 #   we will try each of these directories in order; if none exist,
 #   we will create the last one and use it

--- a/src/trainers.py
+++ b/src/trainers.py
@@ -520,6 +520,23 @@ class BasicTrainer(object):
         last_log = None
         logp_npy_all = []
         argmax_npy_all = []
+
+        # Epoch-based checkpointing support
+        save_epochs = getattr(self.config, 'save_epochs', None)  # e.g., [2, 4, 6]
+        if save_epochs is not None:
+            if isinstance(save_epochs, str):
+                save_epochs = [int(e) for e in save_epochs.split(',')]
+            else:
+                save_epochs = list(save_epochs)
+            saved_epochs = set()
+            rank0_print(f'Will save checkpoints at epochs: {save_epochs}')
+
+        # Calculate examples per epoch (approximate, based on dataset size)
+        # We need to track this to know when epochs complete
+        current_epoch = 0
+        epoch_example_counter = 0
+        examples_per_epoch = self.config.n_examples // self.config.n_epochs if self.config.n_epochs else self.config.n_examples
+
         # reload_ref_required = True
         for batch in self.train_iterator:
             #### BEGIN EVALUATION ####
@@ -571,6 +588,21 @@ class BasicTrainer(object):
 
             self.batch_counter += 1
             self.example_counter += self.config.batch_size
+            epoch_example_counter += self.config.batch_size
+
+            # Check if we've completed an epoch and need to save
+            if examples_per_epoch > 0 and epoch_example_counter >= examples_per_epoch:
+                current_epoch += 1
+                epoch_example_counter = 0
+                rank0_print(f'Completed epoch {current_epoch}')
+
+                # Save checkpoint if this epoch is in save_epochs
+                if save_epochs is not None and current_epoch in save_epochs and current_epoch not in saved_epochs:
+                    saved_epochs.add(current_epoch)
+                    epoch_save_path = os.path.join(self.config.save_path, f'epoch_{current_epoch}')
+                    os.makedirs(epoch_save_path, exist_ok=True)
+                    rank0_print(f'Saving checkpoint for epoch {current_epoch} to {epoch_save_path}')
+                    self.save(epoch_save_path)
 
             if last_log is None or time.time() - last_log > \
                 self.config.minimum_log_interval_secs:


### PR DESCRIPTION
- Add epoch-based checkpointing support in trainers.py (save at epochs 2,4,6)
- Add save_epochs config option in config.yaml
- Create scripts/ directory with comprehensive experiment scripts:
  - setup_environment.sh: Conda environment setup for CUDA 12.x/13.x
  - train_sft_base.sh: SFT training with train_dpo split
  - train_sft_extend.sh: SFT training with train_sft_extend split
  - train_dpo_base.sh: DPO training on base SFT
  - train_dpo_extend.sh: DPO training on extend SFT
  - generate_inference_samples.sh: Generate model responses
  - evaluate_models.py: Compare models using GPT/Claude judge
  - run_all_experiments.sh: Master script to run full pipeline
- Add comprehensive README.md for scripts directory

Configuration: Qwen 1.8B model
- SFT: 2 epochs, 10000 examples, batch_size=4
- DPO: 6 epochs, 30000 examples, batch_size=2, beta=0.1
- Checkpoints saved at DPO epochs 2, 4, and 6